### PR TITLE
Consider sideSwapped during initial load

### DIFF
--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -497,9 +497,9 @@ function newPick(picks) {
 
 function updateSide(sideSwapped, blueName, redName, initialLoad = false) {
 	if (sideSelect === "blue") {
-		side = "B";
+		side = sideSwapped ? "R" : "B";
 	} else if (sideSelect === "red") {
-		side = "R";
+		side = sideSwapped ? "B" : "R";
 	} else {
 		side = "S";
 	}
@@ -516,15 +516,6 @@ function updateSide(sideSwapped, blueName, redName, initialLoad = false) {
 
 	if (initialLoad) {
 		return;
-	}
-
-	switch (side) {
-		case "B":
-			side = sideSwapped ? "R" : "B";
-			break;
-		case "R":
-			side = sideSwapped ? "B" : "R";
-			break;
 	}
 
 	switch (side) {


### PR DESCRIPTION
We were not paying attention to `sideSwapped` switch during initial state setup, only during rendering.

It made possible to start picking for the other team if you refreshed page after a switch.